### PR TITLE
When Actibale object is invisible by default.

### DIFF
--- a/_Level 0/UCE_NetworkedSwitch/Scripts/UCE_ActivateableObject.cs
+++ b/_Level 0/UCE_NetworkedSwitch/Scripts/UCE_ActivateableObject.cs
@@ -76,6 +76,14 @@ public partial class UCE_ActivateableObject : NetworkBehaviour
     private void UCE_SlowUpdate()
     {
         activateableObject.SetActive(_visible);
+	if (_visible == true)
+        {
+            var Mesh = activateableObject.GetComponent<MeshRenderer>();
+            if (Mesh != null)
+            {
+                Mesh.enabled = true;
+            }
+        }
     }
 
     // -----------------------------------------------------------------------------------


### PR DESCRIPTION
Added code to make its mesh enabled. Seems bug. The mesh is disabled if Visible is unchecked by default.